### PR TITLE
Fixed import in reportGeneral.

### DIFF
--- a/routes/reportGeneral.js
+++ b/routes/reportGeneral.js
@@ -1,4 +1,5 @@
-var _ = moment = require('moment')
+var moment = require('moment'),
+    _ = require('underscore')
   ;
 
 /* 


### PR DESCRIPTION
The moment library was inadvertently assigned to the underscore variable, which by convention is for the underscore library and is referenced as such. This fixes that.